### PR TITLE
Remove sequelize models alter table on every run

### DIFF
--- a/data/models.js
+++ b/data/models.js
@@ -83,9 +83,9 @@ module.exports.init = async () => {
         await sequelize.sync({ benchmark: true, force: true, match: /.*_dev$/})
     }
     
-    await Users.sync({ alter: true, benchmark: true})
-    await Subscriptions.sync({ alter: true, benchmark: true})
-    await Notifications.sync({ alter: true, benchmark: true})
+    await Users.sync({ benchmark: true})
+    await Subscriptions.sync({ benchmark: true})
+    await Notifications.sync({ benchmark: true})
 
 }
 


### PR DESCRIPTION
causing an error : SqlError: (conn=5767, no: 1069, SQLState: 42000) Too many keys specified; max 64 keys allowed